### PR TITLE
Fix build / runtime breaks in the API definition and struct files

### DIFF
--- a/ApiDefinition.cs
+++ b/ApiDefinition.cs
@@ -23,9 +23,10 @@ using MonoTouch.ObjCRuntime;
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
 
-namespace Binding
+namespace adalbinding
 {
-	[Model]
+	[Model, Protocol]
+	[BaseType(typeof(NSObject))]
 	public partial interface ADTokenCacheStoring {
 
 		[Export ("allItems")]
@@ -46,15 +47,17 @@ namespace Binding
 		[Export ("removeAll")]
 		void RemoveAll ();
 
-		[Field ("ADAuthenticationErrorDomain")]
+		[Field ("ADAuthenticationErrorDomain", "__Internal")]
 		NSString ADAuthenticationErrorDomain { get; }
 
-		[Field ("ADInvalidArgumentDomain")]
+		[Field ("ADInvalidArgumentDomain", "__Internal")]
 		NSString ADInvalidArgumentDomain { get; }
 
-		[Field ("ADUnauthorizedResponseErrorDomain")]
+		[Field ("ADUnauthorizedResponseErrorDomain", "__Internal")]
 		NSString ADUnauthorizedResponseErrorDomain { get; }
 	}
+
+	public interface IADTokenCacheStoring {}
 
 	[BaseType (typeof (NSError))]
 	public partial interface ADAuthenticationError {
@@ -238,7 +241,7 @@ namespace Binding
 		bool ValidateAuthority { get; set; }
 
 		[Export ("tokenCacheStore")]
-		ADTokenCacheStoring TokenCacheStore { get; set; }
+		IADTokenCacheStoring TokenCacheStore { get; set; }
 
 		[Export ("correlationId")]
 		Guid CorrelationId { get; set; }
@@ -359,7 +362,7 @@ namespace Binding
 		NSObject DispatchQueue { get; set; }
 
 		[Export ("defaultTokenCacheStore")]
-		ADTokenCacheStoring DefaultTokenCacheStore { get; set; }
+		IADTokenCacheStoring DefaultTokenCacheStore { get; set; }
     }
 
 	public delegate void ADParametersCompletion(ADAuthenticationParameters parameters, ADAuthenticationError error);

--- a/StructsAndEnums.cs
+++ b/StructsAndEnums.cs
@@ -19,9 +19,8 @@
 
 using System;
 
-namespace Binding
+namespace adalbinding
 {
-
 	public enum ADAuthenticationResultStatus {
 		SUCCEEDED,
 		USER_CANCELLED,
@@ -71,15 +70,6 @@ namespace Binding
 		OSLittleEndian,
 		OSBigEndian
 	}
-
-//	public enum Mach_port_options_ptr_t    {
-//		GUARD_EXC_DESTROY = 1U << 0,
-//		GUARD_EXC_MOD_REFS = 1U << 1,
-//		GUARD_EXC_SET_CONTEXT = 1U << 2,
-//		GUARD_EXC_UNGUARDED = 1U << 3,
-//		GUARD_EXC_INCORRECT_GUARD = 1U << 4
-//	}
-
 
 	public enum Filesec_property_t   {
 		ILESEC_OWNER = 1,
@@ -180,5 +170,19 @@ namespace Binding
 		UNAUTHORIZED = 401
 	}
 
-}
+	public enum ADCredentialsType{
+		/*!
+     The SDK determines automatically the most suitable option, optimized for user experience.
+     E.g. it may invoke another application for a single sign on, if such application is present.
+     This is the default option.
+     */
+		AD_CREDENTIALS_AUTO,
 
+		/*!
+     The SDK will present an embedded dialog within the application. It will not invoke external
+     application or browser.
+     */
+		AD_CREDENTIALS_EMBEDDED,
+
+	}
+}


### PR DESCRIPTION
There are several issues which prevent the project to build as is, and some that prevent it from running correctly. I've broken down the PR in two commits: the first just changes the indenting of the ApiDefinitions.cs file, and the second actually has the changes, so they can be reviewed easier (by looking at the [commit directly](https://github.com/carlosfigueira/NativeClient-Xamarin-iOS/commit/9a9c6f357c6e58a87cb465ed3e8ad5fa43753839)).

These are the issues which prevented it from building:
- `ADTokenCacheStoring` wasn't decorated with the `[BaseType]` attribute; added it
- `ADTokenCacheStoring` is a protocol, added the `[Protocol]` decoration to it
- Added the `"__Internal"` parameter to the `[Field]` definitions on the `ADTokenCacheStoring` interface, otherwise it wouldn't build. Per the Xamarin documentation: `If you are linking statically, there is no library to bind to, so you need to use the __Internal name`.
- Moved the `ADCredentialsType` enumeration from the ApiDefinition.cs file to StructsAndEnums.cs.

These are issues which prevented it from running correctly:
- The protocol / interface `ADTokenCacheStoring` is returned by both the context and the settings class; to have it working, the properties need to be defined in the interface type, not in the generated type (search for "If you want to use the MyProtocol in an API" in the [Xamarin doc for binding ObjC libraries](http://docs.xamarin.com/guides/ios/advanced_topics/binding_objective-c/binding_objc_libs/).
- The item above also required an empty interface (`IADTokenCacheStoring`) to the API definitions as defined in the Xamarin doc.

Those changes should fix the issues noted in issue #1.
